### PR TITLE
add selected user condition on create channel page

### DIFF
--- a/client/src/components/pages/ChannelCreate.tsx
+++ b/client/src/components/pages/ChannelCreate.tsx
@@ -308,6 +308,8 @@ const ChannelCreate: FC = () => {
 
   useLayoutEffect(() => {
     const pressDone = (): void => {
+      if (selectedUsers.length === 0) return;
+
       const userIds = selectedUsers.map((v) => v.id);
 
       const mutationConfig = {
@@ -332,24 +334,27 @@ const ChannelCreate: FC = () => {
     };
 
     navigation.setOptions({
-      headerRight: (): ReactElement => (
-        <TouchableOpacity testID="touch-done" onPress={pressDone}>
-          <View
-            style={{
-              paddingHorizontal: 16,
-              paddingVertical: 8,
-            }}>
-            <Text
+      headerRight: (): ReactElement =>
+        selectedUsers.length > 0 ? (
+          <TouchableOpacity testID="touch-done" onPress={pressDone}>
+            <View
               style={{
-                color: 'white',
-                fontSize: 14,
-                fontWeight: 'bold',
+                paddingHorizontal: 16,
+                paddingVertical: 8,
               }}>
-              {getString('DONE')}
-            </Text>
-          </View>
-        </TouchableOpacity>
-      ),
+              <Text
+                style={{
+                  color: 'white',
+                  fontSize: 14,
+                  fontWeight: 'bold',
+                }}>
+                {getString('DONE')}
+              </Text>
+            </View>
+          </TouchableOpacity>
+        ) : (
+          <></>
+        ),
     });
   }, [commitChannel, navigation, selectedUsers]);
 


### PR DESCRIPTION
## Specify project
Client

## Description
To prevent creating empty channel, disappearing `Done` button when there is no selected user.
I added some conditon in useLayoutEffect
```
  useLayoutEffect(() => {
    const pressDone = (): void => {
      if (selectedUsers.length === 0) return;
```
and

```
    navigation.setOptions({
      headerRight: (): ReactElement =>
        selectedUsers.length > 0 ? (
          <TouchableOpacity testID="touch-done" onPress={pressDone}>
```

## Related Issues
[Create empty channel · Issue #459 · dooboolab/hackatalk](https://github.com/dooboolab/hackatalk/issues/459)

## Tests

I added the following tests:
Not yet

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
